### PR TITLE
fix: avoid crash when failing to send notify my device message

### DIFF
--- a/orfino/handler.py
+++ b/orfino/handler.py
@@ -10,13 +10,15 @@ logger = logging.getLogger(__name__)
 
 
 def send_notify_my_device_message(
-    api_key: str, title: str, body: str
+    api_key: str, title: str, body: str, log_url_errors: bool
 ) -> typing.Optional[http.client.HTTPResponse]:
     """
     Send a message through the Notify My Device service to your smartphone
     :param api_key: API key generated on notifymydevice.com/myapplications
     :param title: Title of the message (encoding utf-8)
     :param body: Body of the message (encoding utf-8)
+    :param log_url_errors: Decide whether to log URLErrors or not. Must be set to
+    false if used in emit method of some log handler to avoid RecursionError
     :return: Response of
     """
     data = json.dumps({"ApiKey": api_key, "PushTitle": title, "PushText": body})
@@ -28,7 +30,8 @@ def send_notify_my_device_message(
     try:
         response = urllib.request.urlopen(req)
     except urllib.error.URLError as e:
-        logger.warning(f"Unable to send notification via Notify My Device: {e}")
+        if log_url_errors:
+            logger.warning(f"Unable to send notification via Notify My Device: {e}")
         response = None
     return response
 
@@ -57,4 +60,5 @@ class NotifyMyDeviceHandler(logging.Handler):
             api_key=self.api_key,
             title=f"{symbol} {record.filename}",
             body=self.format(record=record),
+            log_url_errors=False,
         )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="orfino",
-    version="0.1.1",
+    version="0.1.2",
     url="https://github.com/maximilianwank/orfino",
     author="Maximilian Wank",
     author_email="orfino@alpenjodel.de",

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -12,7 +12,10 @@ class TestNotifyMyDeviceHandler(TestCase):
 
     @patch("urllib.request.urlopen")
     def test_no_logging_of_url_errors(self, mock_urllib_request_urlopen):
+        # let urllib raise an URLError when trying to send notify my device request
         mock_urllib_request_urlopen.side_effect = urllib.error.URLError("bar")
+        # create sample log record for NotifyMyDeviceHandler.emit call
         log_record = logging.makeLogRecord(dict={"levelno": logging.ERROR})
+        # check that during emit of log record no new log messages are created
         with self.assertNoLogs():
             self.handler.emit(log_record)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,0 +1,18 @@
+import logging
+from unittest import TestCase
+from unittest.mock import patch
+import urllib.error
+
+from orfino.handler import NotifyMyDeviceHandler
+
+
+class TestNotifyMyDeviceHandler(TestCase):
+    def setUp(self) -> None:
+        self.handler = NotifyMyDeviceHandler(api_key="foo")
+
+    @patch("urllib.request.urlopen")
+    def test_no_logging_of_url_errors(self, mock_urllib_request_urlopen):
+        mock_urllib_request_urlopen.side_effect = urllib.error.URLError("bar")
+        log_record = logging.makeLogRecord(dict={"levelno": logging.ERROR})
+        with self.assertNoLogs():
+            self.handler.emit(log_record)


### PR DESCRIPTION
In case of an `urllib.error.URLError`, this exception was logged, which potentially triggered another `urllib.error.URLError` and so on. Eventually, this lead to a `RecursionError`.